### PR TITLE
Add missing headers and update arrow icons

### DIFF
--- a/src/archetypes.hpp
+++ b/src/archetypes.hpp
@@ -2,6 +2,7 @@
 #define ARCHETYPES_HPP
 #include <QMap>
 #include <QtGlobal> // quint16
+#include <utility>
 
 using Archetype = std::pair<quint16, char const*>;
 

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -1,5 +1,6 @@
 #include "main_window.hpp"
 
+#include <array>
 #include <QDateTime>
 #include <QDesktopServices> // openUrl
 #include <QFileDialog>

--- a/src/gui/main_window.ui
+++ b/src/gui/main_window.ui
@@ -436,7 +436,7 @@
                     </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>⬆</string>
+                    <string>↑</string>
                    </property>
                    <property name="checkable">
                     <bool>true</bool>
@@ -474,7 +474,7 @@
                     </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>⬅</string>
+                    <string>←</string>
                    </property>
                    <property name="checkable">
                     <bool>true</bool>
@@ -493,7 +493,7 @@
                     </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>➡</string>
+                    <string>→</string>
                    </property>
                    <property name="checkable">
                     <bool>true</bool>
@@ -531,7 +531,7 @@
                     </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>⬇</string>
+                    <string>↓</string>
                    </property>
                    <property name="checkable">
                     <bool>true</bool>


### PR DESCRIPTION
The characters used for arrows were actually emojis, and ended up being displayed wonkly on windows
![immagine](https://user-images.githubusercontent.com/18705342/233772267-baa7dba4-be0f-4b2d-b7ac-f6c0fc783383.png)
use the same arrow characters that are being used on ygopro instead