### PR TITLE
Properly embed translations

### DIFF
--- a/.github/workflows/x86-windows.yml
+++ b/.github/workflows/x86-windows.yml
@@ -38,9 +38,12 @@ jobs:
         mv v141_xp v141
     - name: Meson build
       shell: cmd
+      # Manually build 6eeb55f@@qt5-compile-es.ts@cus.vcxproj as well
+      # as meson doesn't correctly make the qrc generator depend on it
       run: |
         set PATH=C:\Qt\5.6.3-Static-XP\bin;%PATH%
         meson setup build -Dbackend=vs2017 -Dbuildtype=release -Dstrip=true -Db_lto=true -Db_ndebug=true -Db_vscrt=mt
+        msbuild "build/res/6eeb55f@@qt5-compile-es.ts@cus.vcxproj" -p:Platform=Win32 -p:Configuration=release
         meson compile -C build -j2
     - name: Setup directory with artifacts
       shell: bash

--- a/res/es.ts
+++ b/res/es.ts
@@ -4,12 +4,12 @@
 <context>
     <name>CardCodeNameSqlModel</name>
     <message>
-        <location filename="src/gui/main_window.cpp" line="263"/>
+        <location filename="../src/gui/main_window.cpp" line="263"/>
         <source>Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="264"/>
+        <location filename="../src/gui/main_window.cpp" line="264"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,7 +17,7 @@
 <context>
     <name>FilteringHeader</name>
     <message>
-        <location filename="src/gui/main_window.cpp" line="290"/>
+        <location filename="../src/gui/main_window.cpp" line="290"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
@@ -25,4217 +25,4217 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="src/gui/main_window.ui"/>
-        <source>Database</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/gui/main_window.ui"/>
-        <source>About</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/gui/main_window.ui"/>
-        <source>Español (Spanish)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Datacorn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
+        <source>Database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Card Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>passcode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>alias</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Card Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Scope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
-        <location filename="src/gui/main_window.cpp" line="37"/>
+        <location filename="../src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.cpp" line="37"/>
         <source>Monster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Level/Rank</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Attribute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Race</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Archetypes / Setcodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Strings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>&amp;Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>&amp;Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>&amp;Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>&amp;Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>&amp;New Database...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>&amp;Open Database...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>&amp;Homepage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.ui"/>
         <source>&amp;Close Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
+        <source>Español (Spanish)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/main_window.ui"/>
         <source>English (English)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>&amp;Save Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.ui"/>
+        <location filename="../src/gui/main_window.ui"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="38"/>
+        <location filename="../src/gui/main_window.cpp" line="38"/>
         <source>Spell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="39"/>
+        <location filename="../src/gui/main_window.cpp" line="39"/>
         <source>Trap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="40"/>
+        <location filename="../src/gui/main_window.cpp" line="40"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="41"/>
+        <location filename="../src/gui/main_window.cpp" line="41"/>
         <source>Effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="42"/>
+        <location filename="../src/gui/main_window.cpp" line="42"/>
         <source>Fusion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="43"/>
+        <location filename="../src/gui/main_window.cpp" line="43"/>
         <source>Ritual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="44"/>
+        <location filename="../src/gui/main_window.cpp" line="44"/>
         <source>Trap Monster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="45"/>
-        <location filename="src/archetypes.hpp" line="482"/>
+        <location filename="../src/gui/main_window.cpp" line="45"/>
+        <location filename="../src/archetypes.hpp" line="482"/>
         <source>Spirit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="46"/>
+        <location filename="../src/gui/main_window.cpp" line="46"/>
         <source>Union</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="47"/>
+        <location filename="../src/gui/main_window.cpp" line="47"/>
         <source>Gemini</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="48"/>
+        <location filename="../src/gui/main_window.cpp" line="48"/>
         <source>Tuner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="49"/>
-        <location filename="src/archetypes.hpp" line="225"/>
+        <location filename="../src/gui/main_window.cpp" line="49"/>
+        <location filename="../src/archetypes.hpp" line="225"/>
         <source>Synchro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="50"/>
+        <location filename="../src/gui/main_window.cpp" line="50"/>
         <source>Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="51"/>
+        <location filename="../src/gui/main_window.cpp" line="51"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="52"/>
+        <location filename="../src/gui/main_window.cpp" line="52"/>
         <source>Quick-Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="53"/>
+        <location filename="../src/gui/main_window.cpp" line="53"/>
         <source>Continuous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="54"/>
+        <location filename="../src/gui/main_window.cpp" line="54"/>
         <source>Equip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="55"/>
+        <location filename="../src/gui/main_window.cpp" line="55"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="56"/>
-        <location filename="src/archetypes.hpp" line="327"/>
+        <location filename="../src/gui/main_window.cpp" line="56"/>
+        <location filename="../src/archetypes.hpp" line="327"/>
         <source>Counter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="57"/>
+        <location filename="../src/gui/main_window.cpp" line="57"/>
         <source>Flip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="58"/>
-        <location filename="src/archetypes.hpp" line="551"/>
+        <location filename="../src/gui/main_window.cpp" line="58"/>
+        <location filename="../src/archetypes.hpp" line="551"/>
         <source>Toon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="59"/>
-        <location filename="src/archetypes.hpp" line="571"/>
+        <location filename="../src/gui/main_window.cpp" line="59"/>
+        <location filename="../src/archetypes.hpp" line="571"/>
         <source>Xyz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="60"/>
-        <location filename="src/archetypes.hpp" line="714"/>
+        <location filename="../src/gui/main_window.cpp" line="60"/>
+        <location filename="../src/archetypes.hpp" line="714"/>
         <source>Pendulum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="61"/>
-        <location filename="src/gui/main_window.cpp" line="146"/>
+        <location filename="../src/gui/main_window.cpp" line="61"/>
+        <location filename="../src/gui/main_window.cpp" line="146"/>
         <source>Special Summon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="62"/>
+        <location filename="../src/gui/main_window.cpp" line="62"/>
         <source>Link</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="63"/>
+        <location filename="../src/gui/main_window.cpp" line="63"/>
         <source>Skill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="64"/>
+        <location filename="../src/gui/main_window.cpp" line="64"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="65"/>
+        <location filename="../src/gui/main_window.cpp" line="65"/>
         <source>Plus</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="66"/>
+        <location filename="../src/gui/main_window.cpp" line="66"/>
         <source>Minus</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="67"/>
+        <location filename="../src/gui/main_window.cpp" line="67"/>
         <source>Armor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="70"/>
-        <location filename="src/archetypes.hpp" line="555"/>
+        <location filename="../src/gui/main_window.cpp" line="70"/>
+        <location filename="../src/archetypes.hpp" line="555"/>
         <source>Warrior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="71"/>
+        <location filename="../src/gui/main_window.cpp" line="71"/>
         <source>Spellcaster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="72"/>
-        <location filename="src/archetypes.hpp" line="433"/>
+        <location filename="../src/gui/main_window.cpp" line="72"/>
+        <location filename="../src/archetypes.hpp" line="433"/>
         <source>Fairy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="73"/>
+        <location filename="../src/gui/main_window.cpp" line="73"/>
         <source>Fiend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="74"/>
+        <location filename="../src/gui/main_window.cpp" line="74"/>
         <source>Zombie</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="75"/>
+        <location filename="../src/gui/main_window.cpp" line="75"/>
         <source>Machine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="76"/>
-        <location filename="src/archetypes.hpp" line="675"/>
+        <location filename="../src/gui/main_window.cpp" line="76"/>
+        <location filename="../src/archetypes.hpp" line="675"/>
         <source>Aqua</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="77"/>
+        <location filename="../src/gui/main_window.cpp" line="77"/>
         <source>Pyro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="78"/>
+        <location filename="../src/gui/main_window.cpp" line="78"/>
         <source>Rock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="79"/>
+        <location filename="../src/gui/main_window.cpp" line="79"/>
         <source>Winged-Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="80"/>
+        <location filename="../src/gui/main_window.cpp" line="80"/>
         <source>Plant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="81"/>
+        <location filename="../src/gui/main_window.cpp" line="81"/>
         <source>Insect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="82"/>
+        <location filename="../src/gui/main_window.cpp" line="82"/>
         <source>Thunder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="83"/>
+        <location filename="../src/gui/main_window.cpp" line="83"/>
         <source>Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="84"/>
+        <location filename="../src/gui/main_window.cpp" line="84"/>
         <source>Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="85"/>
+        <location filename="../src/gui/main_window.cpp" line="85"/>
         <source>Beast-Warrior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="86"/>
+        <location filename="../src/gui/main_window.cpp" line="86"/>
         <source>Dinosaur</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="87"/>
+        <location filename="../src/gui/main_window.cpp" line="87"/>
         <source>Fish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="88"/>
+        <location filename="../src/gui/main_window.cpp" line="88"/>
         <source>Sea-Serpent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="89"/>
+        <location filename="../src/gui/main_window.cpp" line="89"/>
         <source>Reptile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="90"/>
+        <location filename="../src/gui/main_window.cpp" line="90"/>
         <source>Psychic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="91"/>
+        <location filename="../src/gui/main_window.cpp" line="91"/>
         <source>Divine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="92"/>
+        <location filename="../src/gui/main_window.cpp" line="92"/>
         <source>Creator God</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="93"/>
+        <location filename="../src/gui/main_window.cpp" line="93"/>
         <source>Wyrm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="94"/>
+        <location filename="../src/gui/main_window.cpp" line="94"/>
         <source>Cyberse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="95"/>
+        <location filename="../src/gui/main_window.cpp" line="95"/>
         <source>Illusionist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="96"/>
+        <location filename="../src/gui/main_window.cpp" line="96"/>
         <source>Cyborg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="97"/>
+        <location filename="../src/gui/main_window.cpp" line="97"/>
         <source>Magical Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="98"/>
+        <location filename="../src/gui/main_window.cpp" line="98"/>
         <source>High Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="99"/>
+        <location filename="../src/gui/main_window.cpp" line="99"/>
         <source>Omega Psychic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="100"/>
+        <location filename="../src/gui/main_window.cpp" line="100"/>
         <source>Celestial Warrior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="101"/>
-        <location filename="src/archetypes.hpp" line="579"/>
+        <location filename="../src/gui/main_window.cpp" line="101"/>
+        <location filename="../src/archetypes.hpp" line="579"/>
         <source>Galaxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="104"/>
+        <location filename="../src/gui/main_window.cpp" line="104"/>
         <source>EARTH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="105"/>
+        <location filename="../src/gui/main_window.cpp" line="105"/>
         <source>WATER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="106"/>
+        <location filename="../src/gui/main_window.cpp" line="106"/>
         <source>FIRE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="107"/>
+        <location filename="../src/gui/main_window.cpp" line="107"/>
         <source>WIND</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="108"/>
+        <location filename="../src/gui/main_window.cpp" line="108"/>
         <source>LIGHT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="109"/>
+        <location filename="../src/gui/main_window.cpp" line="109"/>
         <source>DARK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="110"/>
+        <location filename="../src/gui/main_window.cpp" line="110"/>
         <source>DIVINE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="113"/>
+        <location filename="../src/gui/main_window.cpp" line="113"/>
         <source>OCG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="114"/>
+        <location filename="../src/gui/main_window.cpp" line="114"/>
         <source>TCG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="115"/>
+        <location filename="../src/gui/main_window.cpp" line="115"/>
         <source>Anime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="116"/>
+        <location filename="../src/gui/main_window.cpp" line="116"/>
         <source>Illegal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="117"/>
+        <location filename="../src/gui/main_window.cpp" line="117"/>
         <source>Video Game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="118"/>
+        <location filename="../src/gui/main_window.cpp" line="118"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="119"/>
+        <location filename="../src/gui/main_window.cpp" line="119"/>
         <source>Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="120"/>
+        <location filename="../src/gui/main_window.cpp" line="120"/>
         <source>Pre-Release</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="121"/>
+        <location filename="../src/gui/main_window.cpp" line="121"/>
         <source>Rush</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="122"/>
+        <location filename="../src/gui/main_window.cpp" line="122"/>
         <source>Legend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="123"/>
+        <location filename="../src/gui/main_window.cpp" line="123"/>
         <source>Hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="126"/>
+        <location filename="../src/gui/main_window.cpp" line="126"/>
         <source>Destroy Monster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="127"/>
+        <location filename="../src/gui/main_window.cpp" line="127"/>
         <source>Destroy S/T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="128"/>
+        <location filename="../src/gui/main_window.cpp" line="128"/>
         <source>Destroy Deck</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="129"/>
+        <location filename="../src/gui/main_window.cpp" line="129"/>
         <source>Destroy Hand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="130"/>
+        <location filename="../src/gui/main_window.cpp" line="130"/>
         <source>Send to GY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="131"/>
+        <location filename="../src/gui/main_window.cpp" line="131"/>
         <source>Send to Hand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="132"/>
+        <location filename="../src/gui/main_window.cpp" line="132"/>
         <source>Send to Deck</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="133"/>
+        <location filename="../src/gui/main_window.cpp" line="133"/>
         <source>Banish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="134"/>
+        <location filename="../src/gui/main_window.cpp" line="134"/>
         <source>Draw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="135"/>
+        <location filename="../src/gui/main_window.cpp" line="135"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="136"/>
+        <location filename="../src/gui/main_window.cpp" line="136"/>
         <source>Change ATK/DEF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="137"/>
+        <location filename="../src/gui/main_window.cpp" line="137"/>
         <source>Change Level/Rank</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="138"/>
+        <location filename="../src/gui/main_window.cpp" line="138"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="139"/>
+        <location filename="../src/gui/main_window.cpp" line="139"/>
         <source>Piercing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="140"/>
+        <location filename="../src/gui/main_window.cpp" line="140"/>
         <source>Direct Attack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="141"/>
+        <location filename="../src/gui/main_window.cpp" line="141"/>
         <source>Multi Attack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="142"/>
+        <location filename="../src/gui/main_window.cpp" line="142"/>
         <source>Negate Activation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="143"/>
+        <location filename="../src/gui/main_window.cpp" line="143"/>
         <source>Negate Effect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="144"/>
+        <location filename="../src/gui/main_window.cpp" line="144"/>
         <source>Damage LP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="145"/>
+        <location filename="../src/gui/main_window.cpp" line="145"/>
         <source>Recover LP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="147"/>
+        <location filename="../src/gui/main_window.cpp" line="147"/>
         <source>Non-effect-related</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="148"/>
+        <location filename="../src/gui/main_window.cpp" line="148"/>
         <source>Token-related</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="149"/>
+        <location filename="../src/gui/main_window.cpp" line="149"/>
         <source>Fusion-related</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="150"/>
+        <location filename="../src/gui/main_window.cpp" line="150"/>
         <source>Ritual-related</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="151"/>
+        <location filename="../src/gui/main_window.cpp" line="151"/>
         <source>Synchro-related</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="152"/>
+        <location filename="../src/gui/main_window.cpp" line="152"/>
         <source>Xyz-related</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="153"/>
+        <location filename="../src/gui/main_window.cpp" line="153"/>
         <source>Link-related</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="154"/>
+        <location filename="../src/gui/main_window.cpp" line="154"/>
         <source>Counter-related</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="155"/>
+        <location filename="../src/gui/main_window.cpp" line="155"/>
         <source>Gamble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="156"/>
+        <location filename="../src/gui/main_window.cpp" line="156"/>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="157"/>
+        <location filename="../src/gui/main_window.cpp" line="157"/>
         <source>Move Zones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="458"/>
+        <location filename="../src/gui/main_window.cpp" line="458"/>
         <source>Save Database As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="459"/>
-        <location filename="src/gui/main_window.cpp" line="486"/>
+        <location filename="../src/gui/main_window.cpp" line="459"/>
+        <location filename="../src/gui/main_window.cpp" line="486"/>
         <source>YGOPro Database (*.cdb *.db *.sqlite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="485"/>
+        <location filename="../src/gui/main_window.cpp" line="485"/>
         <source>Select Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="493"/>
-        <location filename="src/gui/main_window.cpp" line="501"/>
+        <location filename="../src/gui/main_window.cpp" line="493"/>
+        <location filename="../src/gui/main_window.cpp" line="501"/>
         <source>Error Opening Database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="502"/>
+        <location filename="../src/gui/main_window.cpp" line="502"/>
         <source>Selected file is not a proper YGOPRO database.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="559"/>
+        <location filename="../src/gui/main_window.cpp" line="559"/>
         <source>Add Archetype?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="560"/>
+        <location filename="../src/gui/main_window.cpp" line="560"/>
         <source>The database schema can only save up to 4 archetypes, even if you add this one it won&apos;t be saved. Proceed anyways?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="587"/>
+        <location filename="../src/gui/main_window.cpp" line="587"/>
         <source>Couldn&apos;t Parse Archetype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="588"/>
+        <location filename="../src/gui/main_window.cpp" line="588"/>
         <source>The currently set archetype could not be parsed either in decimal or hexadecimal format. Either fix the format or select one of the preset archetypes from the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="645"/>
+        <location filename="../src/gui/main_window.cpp" line="645"/>
         <source>Close Opened Database?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="646"/>
+        <location filename="../src/gui/main_window.cpp" line="646"/>
         <source>Do you wish to close the currently opened database?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="785"/>
+        <location filename="../src/gui/main_window.cpp" line="785"/>
         <source>Invalid passcode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/main_window.cpp" line="786"/>
+        <location filename="../src/gui/main_window.cpp" line="786"/>
         <source>Passcode cannot be 0 or empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="10"/>
+        <location filename="../src/archetypes.hpp" line="10"/>
         <source>Ally of Justice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="11"/>
+        <location filename="../src/archetypes.hpp" line="11"/>
         <source>Gusto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="12"/>
+        <location filename="../src/archetypes.hpp" line="12"/>
         <source>Bonding -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="13"/>
+        <location filename="../src/archetypes.hpp" line="13"/>
         <source>R-Genex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="14"/>
+        <location filename="../src/archetypes.hpp" line="14"/>
         <source>Steelswarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="15"/>
+        <location filename="../src/archetypes.hpp" line="15"/>
         <source>X-Saber</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="16"/>
+        <location filename="../src/archetypes.hpp" line="16"/>
         <source>Code Talker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="17"/>
+        <location filename="../src/archetypes.hpp" line="17"/>
         <source>Vehicroid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="18"/>
+        <location filename="../src/archetypes.hpp" line="18"/>
         <source>Synchron</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="19"/>
+        <location filename="../src/archetypes.hpp" line="19"/>
         <source>Mecha Phantom Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="20"/>
+        <location filename="../src/archetypes.hpp" line="20"/>
         <source>Rokket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="21"/>
+        <location filename="../src/archetypes.hpp" line="21"/>
         <source>Armor Ninja</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="22"/>
+        <location filename="../src/archetypes.hpp" line="22"/>
         <source>Altergeist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="23"/>
+        <location filename="../src/archetypes.hpp" line="23"/>
         <source>Assault Blackwing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="24"/>
+        <location filename="../src/archetypes.hpp" line="24"/>
         <source>Crystal Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="25"/>
+        <location filename="../src/archetypes.hpp" line="25"/>
         <source>Secret Six Samurai</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="26"/>
+        <location filename="../src/archetypes.hpp" line="26"/>
         <source>Krawler</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="27"/>
+        <location filename="../src/archetypes.hpp" line="27"/>
         <source>Red Dragon Archfiend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="28"/>
+        <location filename="../src/archetypes.hpp" line="28"/>
         <source>Fusion Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="29"/>
+        <location filename="../src/archetypes.hpp" line="29"/>
         <source>Gem-Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="30"/>
+        <location filename="../src/archetypes.hpp" line="30"/>
         <source>Number C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="31"/>
+        <location filename="../src/archetypes.hpp" line="31"/>
         <source>/Assault Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="32"/>
+        <location filename="../src/archetypes.hpp" line="32"/>
         <source>Metaphys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="33"/>
+        <location filename="../src/archetypes.hpp" line="33"/>
         <source>Starving Venom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="34"/>
+        <location filename="../src/archetypes.hpp" line="34"/>
         <source>Gate Guardian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="35"/>
+        <location filename="../src/archetypes.hpp" line="35"/>
         <source>Vendread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="36"/>
+        <location filename="../src/archetypes.hpp" line="36"/>
         <source>Symphonic Warrior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="37"/>
+        <location filename="../src/archetypes.hpp" line="37"/>
         <source>Djinn of Rituals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="38"/>
+        <location filename="../src/archetypes.hpp" line="38"/>
         <source>Spellbook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="39"/>
+        <location filename="../src/archetypes.hpp" line="39"/>
         <source>Heroic Challenger</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="40"/>
+        <location filename="../src/archetypes.hpp" line="40"/>
         <source>F.A.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="41"/>
+        <location filename="../src/archetypes.hpp" line="41"/>
         <source>Geargiano</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="42"/>
+        <location filename="../src/archetypes.hpp" line="42"/>
         <source>CXyz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="43"/>
+        <location filename="../src/archetypes.hpp" line="43"/>
         <source>Noble Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="44"/>
+        <location filename="../src/archetypes.hpp" line="44"/>
         <source>Galaxy-Eyes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="45"/>
+        <location filename="../src/archetypes.hpp" line="45"/>
         <source>Hazy Flame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="46"/>
+        <location filename="../src/archetypes.hpp" line="46"/>
         <source>ZW -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="47"/>
+        <location filename="../src/archetypes.hpp" line="47"/>
         <source>Utopia</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="48"/>
+        <location filename="../src/archetypes.hpp" line="48"/>
         <source>Magical Musket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="49"/>
+        <location filename="../src/archetypes.hpp" line="49"/>
         <source>Fire King Avatar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="50"/>
+        <location filename="../src/archetypes.hpp" line="50"/>
         <source>Gimmick Puppet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="51"/>
+        <location filename="../src/archetypes.hpp" line="51"/>
         <source>Traptrix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="52"/>
+        <location filename="../src/archetypes.hpp" line="52"/>
         <source>The Weather</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="53"/>
+        <location filename="../src/archetypes.hpp" line="53"/>
         <source>Cyber Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="55"/>
+        <location filename="../src/archetypes.hpp" line="55"/>
         <source>Superheavy Samurai Soul</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="56"/>
+        <location filename="../src/archetypes.hpp" line="56"/>
         <source>Melodious Maestra</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="57"/>
+        <location filename="../src/archetypes.hpp" line="57"/>
         <source>Stellarknight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="58"/>
+        <location filename="../src/archetypes.hpp" line="58"/>
         <source>Parshath</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="59"/>
+        <location filename="../src/archetypes.hpp" line="59"/>
         <source>Dark Magician</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="60"/>
+        <location filename="../src/archetypes.hpp" line="60"/>
         <source>Winged Kuriboh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="61"/>
+        <location filename="../src/archetypes.hpp" line="61"/>
         <source>Apoqliphort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="62"/>
+        <location filename="../src/archetypes.hpp" line="62"/>
         <source>D/D/D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="63"/>
+        <location filename="../src/archetypes.hpp" line="63"/>
         <source>Tindangle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="64"/>
+        <location filename="../src/archetypes.hpp" line="64"/>
         <source>Ritual Beast Tamer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="65"/>
+        <location filename="../src/archetypes.hpp" line="65"/>
         <source>Outer Entity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="66"/>
+        <location filename="../src/archetypes.hpp" line="66"/>
         <source>Mekk-Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="67"/>
+        <location filename="../src/archetypes.hpp" line="67"/>
         <source>Familiar-Possessed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="68"/>
+        <location filename="../src/archetypes.hpp" line="68"/>
         <source>PSY-Framegear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="69"/>
+        <location filename="../src/archetypes.hpp" line="69"/>
         <source>Aquaactress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="70"/>
+        <location filename="../src/archetypes.hpp" line="70"/>
         <source>Black Luster Soldier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="71"/>
+        <location filename="../src/archetypes.hpp" line="71"/>
         <source>Mythical Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="73"/>
+        <location filename="../src/archetypes.hpp" line="73"/>
         <source>Shiranui Spectralsword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="74"/>
+        <location filename="../src/archetypes.hpp" line="74"/>
         <source>The Phantom Knights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="75"/>
+        <location filename="../src/archetypes.hpp" line="75"/>
         <source>Super Quantum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="76"/>
+        <location filename="../src/archetypes.hpp" line="76"/>
         <source>Evolution Pill</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="77"/>
+        <location filename="../src/archetypes.hpp" line="77"/>
         <source>Cubic Seed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="78"/>
+        <location filename="../src/archetypes.hpp" line="78"/>
         <source>Cipher Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="79"/>
+        <location filename="../src/archetypes.hpp" line="79"/>
         <source>Abyss Actor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="80"/>
+        <location filename="../src/archetypes.hpp" line="80"/>
         <source>Subterror Behemoth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="81"/>
+        <location filename="../src/archetypes.hpp" line="81"/>
         <source>SPYRAL GEAR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="82"/>
+        <location filename="../src/archetypes.hpp" line="82"/>
         <source>Borrel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="83"/>
+        <location filename="../src/archetypes.hpp" line="83"/>
         <source>Pendulum Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="84"/>
+        <location filename="../src/archetypes.hpp" line="84"/>
         <source>Predaplant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="85"/>
+        <location filename="../src/archetypes.hpp" line="85"/>
         <source>Supreme King Gate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="86"/>
+        <location filename="../src/archetypes.hpp" line="86"/>
         <source>Karakuri</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="87"/>
+        <location filename="../src/archetypes.hpp" line="87"/>
         <source>Relinquished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="88"/>
+        <location filename="../src/archetypes.hpp" line="88"/>
         <source>Armed Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="89"/>
+        <location filename="../src/archetypes.hpp" line="89"/>
         <source>Eyes Restrict</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="90"/>
+        <location filename="../src/archetypes.hpp" line="90"/>
         <source>Sky Striker Ace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="91"/>
+        <location filename="../src/archetypes.hpp" line="91"/>
         <source>Knightmare</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="92"/>
+        <location filename="../src/archetypes.hpp" line="92"/>
         <source>Rose Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="93"/>
+        <location filename="../src/archetypes.hpp" line="93"/>
         <source>Elemental Lord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="94"/>
+        <location filename="../src/archetypes.hpp" line="94"/>
         <source>Unchained Soul</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="95"/>
+        <location filename="../src/archetypes.hpp" line="95"/>
         <source>Fur Hire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="96"/>
+        <location filename="../src/archetypes.hpp" line="96"/>
         <source>Numeron Gate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="97"/>
+        <location filename="../src/archetypes.hpp" line="97"/>
         <source>Sky Striker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="98"/>
+        <location filename="../src/archetypes.hpp" line="98"/>
         <source>Virtual World Gate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="99"/>
-        <location filename="src/archetypes.hpp" line="521"/>
+        <location filename="../src/archetypes.hpp" line="99"/>
+        <location filename="../src/archetypes.hpp" line="521"/>
         <source>Sunavalon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="100"/>
+        <location filename="../src/archetypes.hpp" line="100"/>
         <source>Crusadia</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="101"/>
+        <location filename="../src/archetypes.hpp" line="101"/>
         <source>GranSolfachord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="103"/>
+        <location filename="../src/archetypes.hpp" line="103"/>
         <source>Mystical Beast of the Forest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="104"/>
+        <location filename="../src/archetypes.hpp" line="104"/>
         <source>Impcantation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="105"/>
-        <location filename="src/archetypes.hpp" line="169"/>
+        <location filename="../src/archetypes.hpp" line="105"/>
+        <location filename="../src/archetypes.hpp" line="169"/>
         <source>Barian&apos;s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="106"/>
+        <location filename="../src/archetypes.hpp" line="106"/>
         <source>Welcome Labrynth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="107"/>
+        <location filename="../src/archetypes.hpp" line="107"/>
         <source>Cynet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="108"/>
-        <location filename="src/archetypes.hpp" line="175"/>
+        <location filename="../src/archetypes.hpp" line="108"/>
+        <location filename="../src/archetypes.hpp" line="175"/>
         <source>Doodle Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="109"/>
+        <location filename="../src/archetypes.hpp" line="109"/>
         <source>Salamangreat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="110"/>
+        <location filename="../src/archetypes.hpp" line="110"/>
         <source>Dinowrestler</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="111"/>
+        <location filename="../src/archetypes.hpp" line="111"/>
         <source>Orcust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="112"/>
+        <location filename="../src/archetypes.hpp" line="112"/>
         <source>Thunder Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="113"/>
+        <location filename="../src/archetypes.hpp" line="113"/>
         <source>Forbidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="114"/>
+        <location filename="../src/archetypes.hpp" line="114"/>
         <source>Danger!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="115"/>
+        <location filename="../src/archetypes.hpp" line="115"/>
         <source>Nephthys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="116"/>
+        <location filename="../src/archetypes.hpp" line="116"/>
         <source>Frog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="117"/>
+        <location filename="../src/archetypes.hpp" line="117"/>
         <source>Prank-Kids</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="118"/>
+        <location filename="../src/archetypes.hpp" line="118"/>
         <source>Mayakashi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="119"/>
+        <location filename="../src/archetypes.hpp" line="119"/>
         <source>Valkyrie</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="120"/>
+        <location filename="../src/archetypes.hpp" line="120"/>
         <source>Rose</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="121"/>
+        <location filename="../src/archetypes.hpp" line="121"/>
         <source>Machine Angel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="122"/>
+        <location filename="../src/archetypes.hpp" line="122"/>
         <source>Smile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="123"/>
+        <location filename="../src/archetypes.hpp" line="123"/>
         <source>Time Thief</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="124"/>
+        <location filename="../src/archetypes.hpp" line="124"/>
         <source>Infinitrack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="125"/>
+        <location filename="../src/archetypes.hpp" line="125"/>
         <source>Witchcrafter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="126"/>
+        <location filename="../src/archetypes.hpp" line="126"/>
         <source>Evil Eye</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="127"/>
+        <location filename="../src/archetypes.hpp" line="127"/>
         <source>Endymion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="128"/>
+        <location filename="../src/archetypes.hpp" line="128"/>
         <source>Marincess</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="129"/>
+        <location filename="../src/archetypes.hpp" line="129"/>
         <source>Tenyi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="130"/>
+        <location filename="../src/archetypes.hpp" line="130"/>
         <source>Simorgh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="131"/>
-        <location filename="src/archetypes.hpp" line="437"/>
+        <location filename="../src/archetypes.hpp" line="131"/>
+        <location filename="../src/archetypes.hpp" line="437"/>
         <source>Fortune Fairy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="132"/>
+        <location filename="../src/archetypes.hpp" line="132"/>
         <source>Battlewasp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="133"/>
+        <location filename="../src/archetypes.hpp" line="133"/>
         <source>Meklord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="134"/>
+        <location filename="../src/archetypes.hpp" line="134"/>
         <source>Unchained</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="135"/>
+        <location filename="../src/archetypes.hpp" line="135"/>
         <source>Dream Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="136"/>
+        <location filename="../src/archetypes.hpp" line="136"/>
         <source>Mathmech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="137"/>
+        <location filename="../src/archetypes.hpp" line="137"/>
         <source>Dragonmaid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="138"/>
+        <location filename="../src/archetypes.hpp" line="138"/>
         <source>Generaider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="139"/>
+        <location filename="../src/archetypes.hpp" line="139"/>
         <source>@Ignister</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="140"/>
+        <location filename="../src/archetypes.hpp" line="140"/>
         <source>A.I.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="141"/>
+        <location filename="../src/archetypes.hpp" line="141"/>
         <source>Ancient Warriors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="142"/>
+        <location filename="../src/archetypes.hpp" line="142"/>
         <source>Megalith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="143"/>
+        <location filename="../src/archetypes.hpp" line="143"/>
         <source>Onomat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="144"/>
+        <location filename="../src/archetypes.hpp" line="144"/>
         <source>Palladium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="145"/>
+        <location filename="../src/archetypes.hpp" line="145"/>
         <source>Rebellion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="146"/>
+        <location filename="../src/archetypes.hpp" line="146"/>
         <source>Codebreaker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="147"/>
+        <location filename="../src/archetypes.hpp" line="147"/>
         <source>Nemeses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="148"/>
+        <location filename="../src/archetypes.hpp" line="148"/>
         <source>Barbaros</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="149"/>
+        <location filename="../src/archetypes.hpp" line="149"/>
         <source>Plunder Patroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="150"/>
+        <location filename="../src/archetypes.hpp" line="150"/>
         <source>Allure Queen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="151"/>
+        <location filename="../src/archetypes.hpp" line="151"/>
         <source>Adamancipator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="152"/>
+        <location filename="../src/archetypes.hpp" line="152"/>
         <source>Rikka</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="153"/>
+        <location filename="../src/archetypes.hpp" line="153"/>
         <source>Eldlich</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="154"/>
+        <location filename="../src/archetypes.hpp" line="154"/>
         <source>Eldlixir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="155"/>
+        <location filename="../src/archetypes.hpp" line="155"/>
         <source>Golden Land</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="156"/>
+        <location filename="../src/archetypes.hpp" line="156"/>
         <source>Phantasm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="157"/>
+        <location filename="../src/archetypes.hpp" line="157"/>
         <source>Dogmatika</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="158"/>
+        <location filename="../src/archetypes.hpp" line="158"/>
         <source>Melffy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="159"/>
+        <location filename="../src/archetypes.hpp" line="159"/>
         <source>Potan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="160"/>
+        <location filename="../src/archetypes.hpp" line="160"/>
         <source>Roland</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="161"/>
-        <location filename="src/archetypes.hpp" line="527"/>
+        <location filename="../src/archetypes.hpp" line="161"/>
+        <location filename="../src/archetypes.hpp" line="527"/>
         <source>Appliancer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="162"/>
+        <location filename="../src/archetypes.hpp" line="162"/>
         <source>Numeron</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="163"/>
+        <location filename="../src/archetypes.hpp" line="163"/>
         <source>Fossil</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="164"/>
+        <location filename="../src/archetypes.hpp" line="164"/>
         <source>Spiritual Art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="165"/>
+        <location filename="../src/archetypes.hpp" line="165"/>
         <source>Dual Avatar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="166"/>
+        <location filename="../src/archetypes.hpp" line="166"/>
         <source>Tri-Brigade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="167"/>
+        <location filename="../src/archetypes.hpp" line="167"/>
         <source>B.E.S.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="168"/>
+        <location filename="../src/archetypes.hpp" line="168"/>
         <source>Virtual World</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="170"/>
+        <location filename="../src/archetypes.hpp" line="170"/>
         <source>Phantom Butterfly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="171"/>
+        <location filename="../src/archetypes.hpp" line="171"/>
         <source>Cat Girl</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="172"/>
+        <location filename="../src/archetypes.hpp" line="172"/>
         <source>Drytron</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="173"/>
+        <location filename="../src/archetypes.hpp" line="173"/>
         <source>Royal Cookpal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="174"/>
-        <location filename="src/archetypes.hpp" line="204"/>
+        <location filename="../src/archetypes.hpp" line="174"/>
+        <location filename="../src/archetypes.hpp" line="204"/>
         <source>Doll Monster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="176"/>
+        <location filename="../src/archetypes.hpp" line="176"/>
         <source>Earthbound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="177"/>
+        <location filename="../src/archetypes.hpp" line="177"/>
         <source>Magic Elf</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="178"/>
+        <location filename="../src/archetypes.hpp" line="178"/>
         <source>Magistus</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="179"/>
+        <location filename="../src/archetypes.hpp" line="179"/>
         <source>Fossil Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="180"/>
+        <location filename="../src/archetypes.hpp" line="180"/>
         <source>Granel Attack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="181"/>
+        <location filename="../src/archetypes.hpp" line="181"/>
         <source>Jester Puppet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="182"/>
+        <location filename="../src/archetypes.hpp" line="182"/>
         <source>Champion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="183"/>
+        <location filename="../src/archetypes.hpp" line="183"/>
         <source>Ki-sikil</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="184"/>
+        <location filename="../src/archetypes.hpp" line="184"/>
         <source>Clock Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="185"/>
+        <location filename="../src/archetypes.hpp" line="185"/>
         <source>Stray Cat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="186"/>
+        <location filename="../src/archetypes.hpp" line="186"/>
         <source>Lil-la</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="187"/>
+        <location filename="../src/archetypes.hpp" line="187"/>
         <source>Quiz Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="188"/>
+        <location filename="../src/archetypes.hpp" line="188"/>
         <source>Skiel Attack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="189"/>
+        <location filename="../src/archetypes.hpp" line="189"/>
         <source>Angel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="190"/>
+        <location filename="../src/archetypes.hpp" line="190"/>
         <source>Spell Spice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="191"/>
+        <location filename="../src/archetypes.hpp" line="191"/>
         <source>Spirit Gem</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="192"/>
+        <location filename="../src/archetypes.hpp" line="192"/>
         <source>Evil★Twin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="193"/>
+        <location filename="../src/archetypes.hpp" line="193"/>
         <source>Pendulumstatue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="194"/>
+        <location filename="../src/archetypes.hpp" line="194"/>
         <source>Tachyon Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="195"/>
+        <location filename="../src/archetypes.hpp" line="195"/>
         <source>&quot; V &quot;/&quot; V &quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="196"/>
+        <location filename="../src/archetypes.hpp" line="196"/>
         <source>White Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="197"/>
+        <location filename="../src/archetypes.hpp" line="197"/>
         <source>Live☆Twin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="198"/>
+        <location filename="../src/archetypes.hpp" line="198"/>
         <source>Wisel Attack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="199"/>
+        <location filename="../src/archetypes.hpp" line="199"/>
         <source>Sun</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="200"/>
+        <location filename="../src/archetypes.hpp" line="200"/>
         <source>Springans</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="201"/>
+        <location filename="../src/archetypes.hpp" line="201"/>
         <source>Myutant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="202"/>
+        <location filename="../src/archetypes.hpp" line="202"/>
         <source>S-Force</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="203"/>
+        <location filename="../src/archetypes.hpp" line="203"/>
         <source>Starry Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="205"/>
+        <location filename="../src/archetypes.hpp" line="205"/>
         <source>Rank-Down-Magic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="206"/>
+        <location filename="../src/archetypes.hpp" line="206"/>
         <source>Amazement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="207"/>
+        <location filename="../src/archetypes.hpp" line="207"/>
         <source>Attraction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="208"/>
+        <location filename="../src/archetypes.hpp" line="208"/>
         <source>roid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="209"/>
+        <location filename="../src/archetypes.hpp" line="209"/>
         <source>Branded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="210"/>
+        <location filename="../src/archetypes.hpp" line="210"/>
         <source>War Rock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="211"/>
+        <location filename="../src/archetypes.hpp" line="211"/>
         <source>Materiactor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="212"/>
+        <location filename="../src/archetypes.hpp" line="212"/>
         <source>Ogdoadic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="213"/>
+        <location filename="../src/archetypes.hpp" line="213"/>
         <source>Solfachord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="214"/>
+        <location filename="../src/archetypes.hpp" line="214"/>
         <source>Ursarctic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="215"/>
+        <location filename="../src/archetypes.hpp" line="215"/>
         <source>Despia</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="216"/>
+        <location filename="../src/archetypes.hpp" line="216"/>
         <source>Magikey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="217"/>
+        <location filename="../src/archetypes.hpp" line="217"/>
         <source>Gunkan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="218"/>
+        <location filename="../src/archetypes.hpp" line="218"/>
         <source>of the Forest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="219"/>
+        <location filename="../src/archetypes.hpp" line="219"/>
         <source>Stealth Kragen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="220"/>
+        <location filename="../src/archetypes.hpp" line="220"/>
         <source>Numerounius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="221"/>
-        <location filename="src/archetypes.hpp" line="387"/>
+        <location filename="../src/archetypes.hpp" line="221"/>
+        <location filename="../src/archetypes.hpp" line="387"/>
         <source>Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="222"/>
+        <location filename="../src/archetypes.hpp" line="222"/>
         <source>Swordsoul</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="223"/>
+        <location filename="../src/archetypes.hpp" line="223"/>
         <source>Icejade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="224"/>
+        <location filename="../src/archetypes.hpp" line="224"/>
         <source>Floowandereeze</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="226"/>
+        <location filename="../src/archetypes.hpp" line="226"/>
         <source>Topologic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="227"/>
+        <location filename="../src/archetypes.hpp" line="227"/>
         <source>Hyperion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="228"/>
+        <location filename="../src/archetypes.hpp" line="228"/>
         <source>Beetrooper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="229"/>
+        <location filename="../src/archetypes.hpp" line="229"/>
         <source>P.U.N.K.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="230"/>
-        <location filename="src/archetypes.hpp" line="231"/>
+        <location filename="../src/archetypes.hpp" line="230"/>
+        <location filename="../src/archetypes.hpp" line="231"/>
         <source>Exosister</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="232"/>
+        <location filename="../src/archetypes.hpp" line="232"/>
         <source>Dinomorphia</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="233"/>
+        <location filename="../src/archetypes.hpp" line="233"/>
         <source>Lady of Lament</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="234"/>
+        <location filename="../src/archetypes.hpp" line="234"/>
         <source>Seventh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="235"/>
-        <location filename="src/archetypes.hpp" line="413"/>
+        <location filename="../src/archetypes.hpp" line="235"/>
+        <location filename="../src/archetypes.hpp" line="413"/>
         <source>Barian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="236"/>
+        <location filename="../src/archetypes.hpp" line="236"/>
         <source>Kairyu-Shin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="237"/>
+        <location filename="../src/archetypes.hpp" line="237"/>
         <source>Sea Stealth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="238"/>
+        <location filename="../src/archetypes.hpp" line="238"/>
         <source>Therion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="239"/>
+        <location filename="../src/archetypes.hpp" line="239"/>
         <source>Scareclaw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="240"/>
+        <location filename="../src/archetypes.hpp" line="240"/>
         <source>Libromancer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="241"/>
+        <location filename="../src/archetypes.hpp" line="241"/>
         <source>Vaylantz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="242"/>
+        <location filename="../src/archetypes.hpp" line="242"/>
         <source>Labrynth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="243"/>
+        <location filename="../src/archetypes.hpp" line="243"/>
         <source>Cloudian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="244"/>
+        <location filename="../src/archetypes.hpp" line="244"/>
         <source>Runick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="245"/>
+        <location filename="../src/archetypes.hpp" line="245"/>
         <source>Spright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="246"/>
+        <location filename="../src/archetypes.hpp" line="246"/>
         <source>Tearlaments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="247"/>
+        <location filename="../src/archetypes.hpp" line="247"/>
         <source>Vernusylph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="248"/>
+        <location filename="../src/archetypes.hpp" line="248"/>
         <source>Mokey Mokey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="249"/>
+        <location filename="../src/archetypes.hpp" line="249"/>
         <source>Wingman</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="250"/>
-        <location filename="src/archetypes.hpp" line="429"/>
+        <location filename="../src/archetypes.hpp" line="250"/>
+        <location filename="../src/archetypes.hpp" line="429"/>
         <source>Doodle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="251"/>
+        <location filename="../src/archetypes.hpp" line="251"/>
         <source>G Golem</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="252"/>
+        <location filename="../src/archetypes.hpp" line="252"/>
         <source>Rainbow Bridge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="253"/>
+        <location filename="../src/archetypes.hpp" line="253"/>
         <source>Byssted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="254"/>
+        <location filename="../src/archetypes.hpp" line="254"/>
         <source>Bystial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="255"/>
+        <location filename="../src/archetypes.hpp" line="255"/>
         <source>Kashtira</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="256"/>
+        <location filename="../src/archetypes.hpp" line="256"/>
         <source>Kshatri-La</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="257"/>
+        <location filename="../src/archetypes.hpp" line="257"/>
         <source>Ghoti</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="258"/>
+        <location filename="../src/archetypes.hpp" line="258"/>
         <source>Rescue-ACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="259"/>
+        <location filename="../src/archetypes.hpp" line="259"/>
         <source>Purery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="260"/>
+        <location filename="../src/archetypes.hpp" line="260"/>
         <source>Purrely</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="261"/>
+        <location filename="../src/archetypes.hpp" line="261"/>
         <source>Mikanko</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="262"/>
+        <location filename="../src/archetypes.hpp" line="262"/>
         <source>Aquamirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="263"/>
+        <location filename="../src/archetypes.hpp" line="263"/>
         <source>Gladiator Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="264"/>
+        <location filename="../src/archetypes.hpp" line="264"/>
         <source>Firewall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="265"/>
+        <location filename="../src/archetypes.hpp" line="265"/>
         <source>Manadome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="266"/>
+        <location filename="../src/archetypes.hpp" line="266"/>
         <source>Nemurelia</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="267"/>
+        <location filename="../src/archetypes.hpp" line="267"/>
         <source>Gold Pride</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="268"/>
+        <location filename="../src/archetypes.hpp" line="268"/>
         <source>Labyrinth Wall</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="269"/>
+        <location filename="../src/archetypes.hpp" line="269"/>
         <source>Favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="270"/>
+        <location filename="../src/archetypes.hpp" line="270"/>
         <source>Vanquish Soul</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="271"/>
+        <location filename="../src/archetypes.hpp" line="271"/>
         <source>Nouvelles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="272"/>
+        <location filename="../src/archetypes.hpp" line="272"/>
         <source>Recipe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="273"/>
+        <location filename="../src/archetypes.hpp" line="273"/>
         <source>Dark Scorpion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="274"/>
+        <location filename="../src/archetypes.hpp" line="274"/>
         <source>Phantom Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="275"/>
+        <location filename="../src/archetypes.hpp" line="275"/>
         <source>Spirit Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="276"/>
+        <location filename="../src/archetypes.hpp" line="276"/>
         <source>Koa&apos;ki Meiru</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="277"/>
+        <location filename="../src/archetypes.hpp" line="277"/>
         <source>Chrysalis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="278"/>
+        <location filename="../src/archetypes.hpp" line="278"/>
         <source>Neo-Spacian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="279"/>
+        <location filename="../src/archetypes.hpp" line="279"/>
         <source>Genex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="280"/>
+        <location filename="../src/archetypes.hpp" line="280"/>
         <source>Shien</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="281"/>
+        <location filename="../src/archetypes.hpp" line="281"/>
         <source>Genex Ally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="282"/>
+        <location filename="../src/archetypes.hpp" line="282"/>
         <source>Speedroid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="283"/>
+        <location filename="../src/archetypes.hpp" line="283"/>
         <source>Synchro Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="284"/>
+        <location filename="../src/archetypes.hpp" line="284"/>
         <source>Blackwing Tamer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="285"/>
+        <location filename="../src/archetypes.hpp" line="285"/>
         <source>Ultimate Crystal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="286"/>
+        <location filename="../src/archetypes.hpp" line="286"/>
         <source>Number S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="287"/>
+        <location filename="../src/archetypes.hpp" line="287"/>
         <source>Magnet Warrior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="288"/>
+        <location filename="../src/archetypes.hpp" line="288"/>
         <source>Heroic Champion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="289"/>
+        <location filename="../src/archetypes.hpp" line="289"/>
         <source>Xyz Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="290"/>
+        <location filename="../src/archetypes.hpp" line="290"/>
         <source>Noble Arms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="291"/>
+        <location filename="../src/archetypes.hpp" line="291"/>
         <source>ZS -</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="292"/>
+        <location filename="../src/archetypes.hpp" line="292"/>
         <source>Utopic Future</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="293"/>
+        <location filename="../src/archetypes.hpp" line="293"/>
         <source>Cyber Angel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="294"/>
+        <location filename="../src/archetypes.hpp" line="294"/>
         <source>Melodious Songstress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="295"/>
+        <location filename="../src/archetypes.hpp" line="295"/>
         <source>Magician Girl</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="296"/>
+        <location filename="../src/archetypes.hpp" line="296"/>
         <source>Spiritual Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="297"/>
+        <location filename="../src/archetypes.hpp" line="297"/>
         <source>Elder Entity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="298"/>
+        <location filename="../src/archetypes.hpp" line="298"/>
         <source>Aquarium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="300"/>
+        <location filename="../src/archetypes.hpp" line="300"/>
         <source>Super Quantal Mech Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="301"/>
+        <location filename="../src/archetypes.hpp" line="301"/>
         <source>Abyss Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="302"/>
+        <location filename="../src/archetypes.hpp" line="302"/>
         <source>SPYRAL MISSION</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="303"/>
+        <location filename="../src/archetypes.hpp" line="303"/>
         <source>Pendulumgraph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="304"/>
+        <location filename="../src/archetypes.hpp" line="304"/>
         <source>Supreme King Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="305"/>
+        <location filename="../src/archetypes.hpp" line="305"/>
         <source>Earthbound Immortal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="306"/>
-        <location filename="src/archetypes.hpp" line="522"/>
+        <location filename="../src/archetypes.hpp" line="306"/>
+        <location filename="../src/archetypes.hpp" line="522"/>
         <source>Sunvine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="308"/>
+        <location filename="../src/archetypes.hpp" line="308"/>
         <source>Mystical Spirit of the Forest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="309"/>
-        <location filename="src/archetypes.hpp" line="315"/>
+        <location filename="../src/archetypes.hpp" line="309"/>
+        <location filename="../src/archetypes.hpp" line="315"/>
         <source>Battleguard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="310"/>
+        <location filename="../src/archetypes.hpp" line="310"/>
         <source>Doodlebook</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="311"/>
+        <location filename="../src/archetypes.hpp" line="311"/>
         <source>Jurrac</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="312"/>
+        <location filename="../src/archetypes.hpp" line="312"/>
         <source>Malefic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="313"/>
+        <location filename="../src/archetypes.hpp" line="313"/>
         <source>Scrap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="314"/>
+        <location filename="../src/archetypes.hpp" line="314"/>
         <source>Iron Chain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="316"/>
+        <location filename="../src/archetypes.hpp" line="316"/>
         <source>Doll Part</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="317"/>
+        <location filename="../src/archetypes.hpp" line="317"/>
         <source>Cenozoic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="318"/>
+        <location filename="../src/archetypes.hpp" line="318"/>
         <source>Granel Guard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="319"/>
+        <location filename="../src/archetypes.hpp" line="319"/>
         <source>Skiel Guard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="320"/>
+        <location filename="../src/archetypes.hpp" line="320"/>
         <source>Celestial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="321"/>
+        <location filename="../src/archetypes.hpp" line="321"/>
         <source>Wisel Guard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="322"/>
+        <location filename="../src/archetypes.hpp" line="322"/>
         <source>Morphtronic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="323"/>
+        <location filename="../src/archetypes.hpp" line="323"/>
         <source>T.G.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="324"/>
+        <location filename="../src/archetypes.hpp" line="324"/>
         <source>Batteryman</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="325"/>
+        <location filename="../src/archetypes.hpp" line="325"/>
         <source>Dragunity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="326"/>
+        <location filename="../src/archetypes.hpp" line="326"/>
         <source>Visas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="328"/>
+        <location filename="../src/archetypes.hpp" line="328"/>
         <source>Battlin&apos; Boxing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="329"/>
+        <location filename="../src/archetypes.hpp" line="329"/>
         <source>Naturia</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="330"/>
+        <location filename="../src/archetypes.hpp" line="330"/>
         <source>Ninja</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="331"/>
+        <location filename="../src/archetypes.hpp" line="331"/>
         <source>Flamvell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="332"/>
+        <location filename="../src/archetypes.hpp" line="332"/>
         <source>Nitro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="333"/>
+        <location filename="../src/archetypes.hpp" line="333"/>
         <source>Gravekeeper&apos;s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="334"/>
+        <location filename="../src/archetypes.hpp" line="334"/>
         <source>Ice Barrier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="336"/>
+        <location filename="../src/archetypes.hpp" line="336"/>
         <source>Horus the Black Flame Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="337"/>
+        <location filename="../src/archetypes.hpp" line="337"/>
         <source>Vylon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="338"/>
+        <location filename="../src/archetypes.hpp" line="338"/>
         <source>Elemental HERO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="339"/>
+        <location filename="../src/archetypes.hpp" line="339"/>
         <source>XX-Saber</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="340"/>
+        <location filename="../src/archetypes.hpp" line="340"/>
         <source>Meklord Emperor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="341"/>
+        <location filename="../src/archetypes.hpp" line="341"/>
         <source>Nordic Ascendant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="342"/>
+        <location filename="../src/archetypes.hpp" line="342"/>
         <source>Evoltile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="344"/>
+        <location filename="../src/archetypes.hpp" line="344"/>
         <source>Galaxy-Eyes Tachyon Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="345"/>
+        <location filename="../src/archetypes.hpp" line="345"/>
         <source>Dark Magician Girl</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="346"/>
+        <location filename="../src/archetypes.hpp" line="346"/>
         <source>Spiritual Beast Tamer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="347"/>
+        <location filename="../src/archetypes.hpp" line="347"/>
         <source>Fortune Lady</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="348"/>
+        <location filename="../src/archetypes.hpp" line="348"/>
         <source>Spiritual Earth Art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="349"/>
+        <location filename="../src/archetypes.hpp" line="349"/>
         <source>Darkness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="350"/>
+        <location filename="../src/archetypes.hpp" line="350"/>
         <source>Volcanic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="351"/>
+        <location filename="../src/archetypes.hpp" line="351"/>
         <source>Blackwing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="352"/>
+        <location filename="../src/archetypes.hpp" line="352"/>
         <source>Crystal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="353"/>
+        <location filename="../src/archetypes.hpp" line="353"/>
         <source>Fabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="354"/>
+        <location filename="../src/archetypes.hpp" line="354"/>
         <source>Earthbound Servant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="356"/>
+        <location filename="../src/archetypes.hpp" line="356"/>
         <source>Cenozoic Fossil Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="357"/>
+        <location filename="../src/archetypes.hpp" line="357"/>
         <source>Machina</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="358"/>
+        <location filename="../src/archetypes.hpp" line="358"/>
         <source>Mist Valley</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="359"/>
+        <location filename="../src/archetypes.hpp" line="359"/>
         <source>Lightsworn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="360"/>
+        <location filename="../src/archetypes.hpp" line="360"/>
         <source>Laval</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="361"/>
+        <location filename="../src/archetypes.hpp" line="361"/>
         <source>Gishki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="362"/>
+        <location filename="../src/archetypes.hpp" line="362"/>
         <source>Red-Eyes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="363"/>
+        <location filename="../src/archetypes.hpp" line="363"/>
         <source>Reptilianne</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="364"/>
+        <location filename="../src/archetypes.hpp" line="364"/>
         <source>Six Samurai</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="365"/>
+        <location filename="../src/archetypes.hpp" line="365"/>
         <source>Worm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="366"/>
+        <location filename="../src/archetypes.hpp" line="366"/>
         <source>Majestic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="367"/>
+        <location filename="../src/archetypes.hpp" line="367"/>
         <source>Amazoness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="368"/>
+        <location filename="../src/archetypes.hpp" line="368"/>
         <source>Forbidden One</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="369"/>
+        <location filename="../src/archetypes.hpp" line="369"/>
         <source>Elementsaber</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="370"/>
+        <location filename="../src/archetypes.hpp" line="370"/>
         <source>Infernoble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="371"/>
+        <location filename="../src/archetypes.hpp" line="371"/>
         <source>Cyberdark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="372"/>
+        <location filename="../src/archetypes.hpp" line="372"/>
         <source>Ritual Beast Ulti-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="373"/>
+        <location filename="../src/archetypes.hpp" line="373"/>
         <source>Old Entity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="374"/>
+        <location filename="../src/archetypes.hpp" line="374"/>
         <source>Abyss Costume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="375"/>
+        <location filename="../src/archetypes.hpp" line="375"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="376"/>
+        <location filename="../src/archetypes.hpp" line="376"/>
         <source>Sunseed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="377"/>
+        <location filename="../src/archetypes.hpp" line="377"/>
         <source>Nordic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="378"/>
+        <location filename="../src/archetypes.hpp" line="378"/>
         <source>Junk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="379"/>
+        <location filename="../src/archetypes.hpp" line="379"/>
         <source>The Agent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="380"/>
+        <location filename="../src/archetypes.hpp" line="380"/>
         <source>Archfiend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="381"/>
+        <location filename="../src/archetypes.hpp" line="381"/>
         <source>Mezozoic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="382"/>
+        <location filename="../src/archetypes.hpp" line="382"/>
         <source>Granel Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="383"/>
+        <location filename="../src/archetypes.hpp" line="383"/>
         <source>Skiel Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="384"/>
+        <location filename="../src/archetypes.hpp" line="384"/>
         <source>Wisel Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="385"/>
+        <location filename="../src/archetypes.hpp" line="385"/>
         <source>Polymerization|Fusion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="386"/>
+        <location filename="../src/archetypes.hpp" line="386"/>
         <source>Gem-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="388"/>
+        <location filename="../src/archetypes.hpp" line="388"/>
         <source>Skyblaster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="389"/>
+        <location filename="../src/archetypes.hpp" line="389"/>
         <source>Timelord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="390"/>
+        <location filename="../src/archetypes.hpp" line="390"/>
         <source>Aesir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="391"/>
+        <location filename="../src/archetypes.hpp" line="391"/>
         <source>Trap Hole</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="392"/>
+        <location filename="../src/archetypes.hpp" line="392"/>
         <source>Beast&apos;s Battle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="393"/>
+        <location filename="../src/archetypes.hpp" line="393"/>
         <source>Evol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="394"/>
+        <location filename="../src/archetypes.hpp" line="394"/>
         <source>Dark Lucius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="395"/>
+        <location filename="../src/archetypes.hpp" line="395"/>
         <source>Arcana Force</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="396"/>
+        <location filename="../src/archetypes.hpp" line="396"/>
         <source>Venom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="397"/>
+        <location filename="../src/archetypes.hpp" line="397"/>
         <source>Speed Spell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="398"/>
+        <location filename="../src/archetypes.hpp" line="398"/>
         <source>Vision HERO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="399"/>
+        <location filename="../src/archetypes.hpp" line="399"/>
         <source>Alchemy Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="400"/>
+        <location filename="../src/archetypes.hpp" line="400"/>
         <source>Alligator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="401"/>
+        <location filename="../src/archetypes.hpp" line="401"/>
         <source>Anti</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="403"/>
+        <location filename="../src/archetypes.hpp" line="403"/>
         <source>Advanced Crystal Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="404"/>
+        <location filename="../src/archetypes.hpp" line="404"/>
         <source>Assassin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="405"/>
+        <location filename="../src/archetypes.hpp" line="405"/>
         <source>Nordic Relic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="406"/>
+        <location filename="../src/archetypes.hpp" line="406"/>
         <source>Number C39</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="407"/>
+        <location filename="../src/archetypes.hpp" line="407"/>
         <source>Evolzar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="408"/>
+        <location filename="../src/archetypes.hpp" line="408"/>
         <source>Astral</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="409"/>
+        <location filename="../src/archetypes.hpp" line="409"/>
         <source>Atlandis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="410"/>
+        <location filename="../src/archetypes.hpp" line="410"/>
         <source>Attack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="411"/>
+        <location filename="../src/archetypes.hpp" line="411"/>
         <source>Infernoble Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="412"/>
+        <location filename="../src/archetypes.hpp" line="412"/>
         <source>Baby</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="414"/>
+        <location filename="../src/archetypes.hpp" line="414"/>
         <source>Beastborg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="415"/>
+        <location filename="../src/archetypes.hpp" line="415"/>
         <source>Butterfly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="416"/>
+        <location filename="../src/archetypes.hpp" line="416"/>
         <source>Carrier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="417"/>
+        <location filename="../src/archetypes.hpp" line="417"/>
         <source>Cat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="418"/>
+        <location filename="../src/archetypes.hpp" line="418"/>
         <source>Cicada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="419"/>
+        <location filename="../src/archetypes.hpp" line="419"/>
         <source>Gadget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="420"/>
+        <location filename="../src/archetypes.hpp" line="420"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="421"/>
+        <location filename="../src/archetypes.hpp" line="421"/>
         <source>Comics Hero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="422"/>
+        <location filename="../src/archetypes.hpp" line="422"/>
         <source>Cookpal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="423"/>
+        <location filename="../src/archetypes.hpp" line="423"/>
         <source>Dart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="424"/>
+        <location filename="../src/archetypes.hpp" line="424"/>
         <source>Dice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="425"/>
+        <location filename="../src/archetypes.hpp" line="425"/>
         <source>Spiritual Fire Art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="426"/>
+        <location filename="../src/archetypes.hpp" line="426"/>
         <source>Dizzy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="427"/>
+        <location filename="../src/archetypes.hpp" line="427"/>
         <source>Dog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="428"/>
+        <location filename="../src/archetypes.hpp" line="428"/>
         <source>Doll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="430"/>
+        <location filename="../src/archetypes.hpp" line="430"/>
         <source>Dyson</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="431"/>
+        <location filename="../src/archetypes.hpp" line="431"/>
         <source>Earth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="432"/>
+        <location filename="../src/archetypes.hpp" line="432"/>
         <source>Elf</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="434"/>
+        <location filename="../src/archetypes.hpp" line="434"/>
         <source>Forbidden Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="435"/>
+        <location filename="../src/archetypes.hpp" line="435"/>
         <source>Forest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="436"/>
+        <location filename="../src/archetypes.hpp" line="436"/>
         <source>Guardian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="439"/>
+        <location filename="../src/archetypes.hpp" line="439"/>
         <source>Gaia the Dragon Champion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="440"/>
+        <location filename="../src/archetypes.hpp" line="440"/>
         <source>Gorgonic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="441"/>
+        <location filename="../src/archetypes.hpp" line="441"/>
         <source>Goyo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="442"/>
+        <location filename="../src/archetypes.hpp" line="442"/>
         <source>Granel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="443"/>
+        <location filename="../src/archetypes.hpp" line="443"/>
         <source>Guard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="444"/>
+        <location filename="../src/archetypes.hpp" line="444"/>
         <source>Guts Master</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="445"/>
+        <location filename="../src/archetypes.hpp" line="445"/>
         <source>Hand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="446"/>
+        <location filename="../src/archetypes.hpp" line="446"/>
         <source>Heart Monster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="447"/>
+        <location filename="../src/archetypes.hpp" line="447"/>
         <source>Heavy Industry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="448"/>
+        <location filename="../src/archetypes.hpp" line="448"/>
         <source>Inu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="449"/>
+        <location filename="../src/archetypes.hpp" line="449"/>
         <source>Ivy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="450"/>
+        <location filename="../src/archetypes.hpp" line="450"/>
         <source>Jester</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="451"/>
+        <location filename="../src/archetypes.hpp" line="451"/>
         <source>Jutte</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="452"/>
+        <location filename="../src/archetypes.hpp" line="452"/>
         <source>Kabuki Stage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="453"/>
+        <location filename="../src/archetypes.hpp" line="453"/>
         <source>King</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="454"/>
+        <location filename="../src/archetypes.hpp" line="454"/>
         <source>Constellar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="455"/>
+        <location filename="../src/archetypes.hpp" line="455"/>
         <source>Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="456"/>
-        <location filename="src/archetypes.hpp" line="557"/>
+        <location filename="../src/archetypes.hpp" line="456"/>
+        <location filename="../src/archetypes.hpp" line="557"/>
         <source>Koala</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="457"/>
+        <location filename="../src/archetypes.hpp" line="457"/>
         <source>Landstar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="458"/>
+        <location filename="../src/archetypes.hpp" line="458"/>
         <source>Magnet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="459"/>
+        <location filename="../src/archetypes.hpp" line="459"/>
         <source>Mantis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="460"/>
+        <location filename="../src/archetypes.hpp" line="460"/>
         <source>Mosquito</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="461"/>
+        <location filename="../src/archetypes.hpp" line="461"/>
         <source>Motor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="462"/>
+        <location filename="../src/archetypes.hpp" line="462"/>
         <source>Neko</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="463"/>
+        <location filename="../src/archetypes.hpp" line="463"/>
         <source>Numeronius</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="464"/>
+        <location filename="../src/archetypes.hpp" line="464"/>
         <source>Papillon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="465"/>
+        <location filename="../src/archetypes.hpp" line="465"/>
         <source>Parasite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="466"/>
+        <location filename="../src/archetypes.hpp" line="466"/>
         <source>Pixie</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="467"/>
+        <location filename="../src/archetypes.hpp" line="467"/>
         <source>Priestess</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="468"/>
+        <location filename="../src/archetypes.hpp" line="468"/>
         <source>Gagaga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="469"/>
-        <location filename="src/archetypes.hpp" line="588"/>
+        <location filename="../src/archetypes.hpp" line="469"/>
+        <location filename="../src/archetypes.hpp" line="588"/>
         <source>Puppet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="470"/>
+        <location filename="../src/archetypes.hpp" line="470"/>
         <source>Quiz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="471"/>
+        <location filename="../src/archetypes.hpp" line="471"/>
         <source>Raccoon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="472"/>
+        <location filename="../src/archetypes.hpp" line="472"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="473"/>
+        <location filename="../src/archetypes.hpp" line="473"/>
         <source>Seal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="474"/>
+        <location filename="../src/archetypes.hpp" line="474"/>
         <source>Shaman</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="475"/>
+        <location filename="../src/archetypes.hpp" line="475"/>
         <source>Shark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="476"/>
+        <location filename="../src/archetypes.hpp" line="476"/>
         <source>Shining</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="477"/>
+        <location filename="../src/archetypes.hpp" line="477"/>
         <source>Skiel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="478"/>
+        <location filename="../src/archetypes.hpp" line="478"/>
         <source>Sky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="479"/>
+        <location filename="../src/archetypes.hpp" line="479"/>
         <source>Slime</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="480"/>
+        <location filename="../src/archetypes.hpp" line="480"/>
         <source>Sphere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="481"/>
+        <location filename="../src/archetypes.hpp" line="481"/>
         <source>Spice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="483"/>
+        <location filename="../src/archetypes.hpp" line="483"/>
         <source>Starship</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="484"/>
+        <location filename="../src/archetypes.hpp" line="484"/>
         <source>Photon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="485"/>
+        <location filename="../src/archetypes.hpp" line="485"/>
         <source>Statue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="486"/>
+        <location filename="../src/archetypes.hpp" line="486"/>
         <source>Stone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="487"/>
+        <location filename="../src/archetypes.hpp" line="487"/>
         <source>Strain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="489"/>
+        <location filename="../src/archetypes.hpp" line="489"/>
         <source>Mezozoic Fossil Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="490"/>
+        <location filename="../src/archetypes.hpp" line="490"/>
         <source>Tachyon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="491"/>
+        <location filename="../src/archetypes.hpp" line="491"/>
         <source>Thorn Prisoner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="492"/>
+        <location filename="../src/archetypes.hpp" line="492"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="493"/>
+        <location filename="../src/archetypes.hpp" line="493"/>
         <source>Toy (Arc-V)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="494"/>
+        <location filename="../src/archetypes.hpp" line="494"/>
         <source>Toy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="495"/>
+        <location filename="../src/archetypes.hpp" line="495"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="496"/>
+        <location filename="../src/archetypes.hpp" line="496"/>
         <source>Vigilante</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="497"/>
+        <location filename="../src/archetypes.hpp" line="497"/>
         <source>White</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="498"/>
+        <location filename="../src/archetypes.hpp" line="498"/>
         <source>Sinister Doctrine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="499"/>
+        <location filename="../src/archetypes.hpp" line="499"/>
         <source>Inzektor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="500"/>
+        <location filename="../src/archetypes.hpp" line="500"/>
         <source>Wisel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="501"/>
+        <location filename="../src/archetypes.hpp" line="501"/>
         <source>Yubel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="502"/>
+        <location filename="../src/archetypes.hpp" line="502"/>
         <source>∞</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="503"/>
+        <location filename="../src/archetypes.hpp" line="503"/>
         <source>Yomi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="504"/>
+        <location filename="../src/archetypes.hpp" line="504"/>
         <source>Shogi|Line Monster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="505"/>
+        <location filename="../src/archetypes.hpp" line="505"/>
         <source>Hunder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="506"/>
+        <location filename="../src/archetypes.hpp" line="506"/>
         <source>Heraldic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="507"/>
+        <location filename="../src/archetypes.hpp" line="507"/>
         <source>Hell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="508"/>
+        <location filename="../src/archetypes.hpp" line="508"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="509"/>
+        <location filename="../src/archetypes.hpp" line="509"/>
         <source>Eco Spell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="510"/>
+        <location filename="../src/archetypes.hpp" line="510"/>
         <source>Junk Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="511"/>
+        <location filename="../src/archetypes.hpp" line="511"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="512"/>
+        <location filename="../src/archetypes.hpp" line="512"/>
         <source>X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="513"/>
+        <location filename="../src/archetypes.hpp" line="513"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="514"/>
+        <location filename="../src/archetypes.hpp" line="514"/>
         <source>Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="515"/>
+        <location filename="../src/archetypes.hpp" line="515"/>
         <source>Dark Mummy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="516"/>
+        <location filename="../src/archetypes.hpp" line="516"/>
         <source>Resonator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="517"/>
+        <location filename="../src/archetypes.hpp" line="517"/>
         <source>Tentacluster</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="518"/>
+        <location filename="../src/archetypes.hpp" line="518"/>
         <source>Monarch (monster)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="519"/>
+        <location filename="../src/archetypes.hpp" line="519"/>
         <source>Mirror Imagine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="520"/>
+        <location filename="../src/archetypes.hpp" line="520"/>
         <source>Helixx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="523"/>
+        <location filename="../src/archetypes.hpp" line="523"/>
         <source>Starving Venemy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="524"/>
+        <location filename="../src/archetypes.hpp" line="524"/>
         <source>Hydradrive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="525"/>
+        <location filename="../src/archetypes.hpp" line="525"/>
         <source>Armatos Legio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="526"/>
+        <location filename="../src/archetypes.hpp" line="526"/>
         <source>D-Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="528"/>
+        <location filename="../src/archetypes.hpp" line="528"/>
         <source>Topologina</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="529"/>
+        <location filename="../src/archetypes.hpp" line="529"/>
         <source>Wind-Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="530"/>
+        <location filename="../src/archetypes.hpp" line="530"/>
         <source>Stormrider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="531"/>
+        <location filename="../src/archetypes.hpp" line="531"/>
         <source>Drone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="532"/>
+        <location filename="../src/archetypes.hpp" line="532"/>
         <source>Mask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="533"/>
+        <location filename="../src/archetypes.hpp" line="533"/>
         <source>Gogogo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="534"/>
+        <location filename="../src/archetypes.hpp" line="534"/>
         <source>Penguin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="535"/>
+        <location filename="../src/archetypes.hpp" line="535"/>
         <source>Inmato</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="536"/>
+        <location filename="../src/archetypes.hpp" line="536"/>
         <source>Sphinx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="537"/>
+        <location filename="../src/archetypes.hpp" line="537"/>
         <source>Ultimate Insect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="538"/>
+        <location filename="../src/archetypes.hpp" line="538"/>
         <source>Dark Mimic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="539"/>
+        <location filename="../src/archetypes.hpp" line="539"/>
         <source>Mystic Swordsman</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="540"/>
+        <location filename="../src/archetypes.hpp" line="540"/>
         <source>Dark World</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="541"/>
+        <location filename="../src/archetypes.hpp" line="541"/>
         <source>Bamboo Sword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="542"/>
+        <location filename="../src/archetypes.hpp" line="542"/>
         <source>Dark Tuner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="543"/>
+        <location filename="../src/archetypes.hpp" line="543"/>
         <source>Evil HERO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="544"/>
+        <location filename="../src/archetypes.hpp" line="544"/>
         <source>Dark Synchro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="545"/>
+        <location filename="../src/archetypes.hpp" line="545"/>
         <source>Meklord Army</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="546"/>
+        <location filename="../src/archetypes.hpp" line="546"/>
         <source>Nordic Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="547"/>
+        <location filename="../src/archetypes.hpp" line="547"/>
         <source>Evolsaur</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="548"/>
+        <location filename="../src/archetypes.hpp" line="548"/>
         <source>Infernoble Arms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="549"/>
+        <location filename="../src/archetypes.hpp" line="549"/>
         <source>Ninjitsu Art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="550"/>
+        <location filename="../src/archetypes.hpp" line="550"/>
         <source>Spiritual Water Art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="552"/>
+        <location filename="../src/archetypes.hpp" line="552"/>
         <source>Reactor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="553"/>
+        <location filename="../src/archetypes.hpp" line="553"/>
         <source>Harpie</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="554"/>
+        <location filename="../src/archetypes.hpp" line="554"/>
         <source>Infestation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="556"/>
+        <location filename="../src/archetypes.hpp" line="556"/>
         <source>Iron</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="558"/>
+        <location filename="../src/archetypes.hpp" line="558"/>
         <source>Kangaroo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="559"/>
+        <location filename="../src/archetypes.hpp" line="559"/>
         <source>Tin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="560"/>
+        <location filename="../src/archetypes.hpp" line="560"/>
         <source>Hieratic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="561"/>
+        <location filename="../src/archetypes.hpp" line="561"/>
         <source>Butterspy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="562"/>
+        <location filename="../src/archetypes.hpp" line="562"/>
         <source>Bounzer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="563"/>
+        <location filename="../src/archetypes.hpp" line="563"/>
         <source>Lightray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="564"/>
+        <location filename="../src/archetypes.hpp" line="564"/>
         <source>Djinn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="565"/>
+        <location filename="../src/archetypes.hpp" line="565"/>
         <source>Prophecy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="566"/>
+        <location filename="../src/archetypes.hpp" line="566"/>
         <source>Heroic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="567"/>
+        <location filename="../src/archetypes.hpp" line="567"/>
         <source>Ancient Gear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="568"/>
+        <location filename="../src/archetypes.hpp" line="568"/>
         <source>Chronomaly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="569"/>
+        <location filename="../src/archetypes.hpp" line="569"/>
         <source>Madolche</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="570"/>
+        <location filename="../src/archetypes.hpp" line="570"/>
         <source>Geargia</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="572"/>
+        <location filename="../src/archetypes.hpp" line="572"/>
         <source>Mermail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="573"/>
+        <location filename="../src/archetypes.hpp" line="573"/>
         <source>Abyss-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="574"/>
+        <location filename="../src/archetypes.hpp" line="574"/>
         <source>Heraldic Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="575"/>
+        <location filename="../src/archetypes.hpp" line="575"/>
         <source>Atlantean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="576"/>
+        <location filename="../src/archetypes.hpp" line="576"/>
         <source>Nimble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="577"/>
+        <location filename="../src/archetypes.hpp" line="577"/>
         <source>Fire Fist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="578"/>
+        <location filename="../src/archetypes.hpp" line="578"/>
         <source>Noble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="580"/>
+        <location filename="../src/archetypes.hpp" line="580"/>
         <source>Fire Formation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="581"/>
+        <location filename="../src/archetypes.hpp" line="581"/>
         <source>Hazy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="582"/>
+        <location filename="../src/archetypes.hpp" line="582"/>
         <source>Zexal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="583"/>
+        <location filename="../src/archetypes.hpp" line="583"/>
         <source>Utopic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="584"/>
+        <location filename="../src/archetypes.hpp" line="584"/>
         <source>HERO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="585"/>
+        <location filename="../src/archetypes.hpp" line="585"/>
         <source>Duston</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="586"/>
+        <location filename="../src/archetypes.hpp" line="586"/>
         <source>Fire King</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="587"/>
+        <location filename="../src/archetypes.hpp" line="587"/>
         <source>Dododo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="589"/>
+        <location filename="../src/archetypes.hpp" line="589"/>
         <source>Battlin&apos; Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="590"/>
+        <location filename="../src/archetypes.hpp" line="590"/>
         <source>Super Defense Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="591"/>
-        <location filename="src/archetypes.hpp" line="682"/>
+        <location filename="../src/archetypes.hpp" line="591"/>
+        <location filename="../src/archetypes.hpp" line="682"/>
         <source>Paleozoic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="592"/>
+        <location filename="../src/archetypes.hpp" line="592"/>
         <source>Granel Carrier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="593"/>
+        <location filename="../src/archetypes.hpp" line="593"/>
         <source>Skiel Carrier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="594"/>
+        <location filename="../src/archetypes.hpp" line="594"/>
         <source>Wisel Carrier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="595"/>
+        <location filename="../src/archetypes.hpp" line="595"/>
         <source>Star Seraph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="596"/>
+        <location filename="../src/archetypes.hpp" line="596"/>
         <source>Umbral Horror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="597"/>
+        <location filename="../src/archetypes.hpp" line="597"/>
         <source>Bujin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="598"/>
+        <location filename="../src/archetypes.hpp" line="598"/>
         <source>Hole</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="599"/>
+        <location filename="../src/archetypes.hpp" line="599"/>
         <source>Envy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="600"/>
+        <location filename="../src/archetypes.hpp" line="600"/>
         <source>Malicevorous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="601"/>
+        <location filename="../src/archetypes.hpp" line="601"/>
         <source>Druid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="602"/>
+        <location filename="../src/archetypes.hpp" line="602"/>
         <source>Ghostrick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="603"/>
+        <location filename="../src/archetypes.hpp" line="603"/>
         <source>Vampire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="604"/>
+        <location filename="../src/archetypes.hpp" line="604"/>
         <source>Zubaba</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="605"/>
+        <location filename="../src/archetypes.hpp" line="605"/>
         <source>Neos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="606"/>
+        <location filename="../src/archetypes.hpp" line="606"/>
         <source>Sylvan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="607"/>
+        <location filename="../src/archetypes.hpp" line="607"/>
         <source>Meklord Astro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="608"/>
+        <location filename="../src/archetypes.hpp" line="608"/>
         <source>Necrovalley</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="609"/>
+        <location filename="../src/archetypes.hpp" line="609"/>
         <source>Heraldry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="610"/>
+        <location filename="../src/archetypes.hpp" line="610"/>
         <source>Cyber</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="611"/>
+        <location filename="../src/archetypes.hpp" line="611"/>
         <source>Cybernetic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="612"/>
+        <location filename="../src/archetypes.hpp" line="612"/>
         <source>Rank-Up-Magic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="614"/>
+        <location filename="../src/archetypes.hpp" line="614"/>
         <source>Paleozoic Fossil Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="615"/>
+        <location filename="../src/archetypes.hpp" line="615"/>
         <source>Fishborg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="616"/>
+        <location filename="../src/archetypes.hpp" line="616"/>
         <source>Artifact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="617"/>
-        <location filename="src/archetypes.hpp" line="631"/>
+        <location filename="../src/archetypes.hpp" line="617"/>
+        <location filename="../src/archetypes.hpp" line="631"/>
         <source>Magician</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="618"/>
+        <location filename="../src/archetypes.hpp" line="618"/>
         <source>Odd-Eyes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="619"/>
+        <location filename="../src/archetypes.hpp" line="619"/>
         <source>Superheavy Samurai</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="620"/>
+        <location filename="../src/archetypes.hpp" line="620"/>
         <source>Melodious</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="621"/>
+        <location filename="../src/archetypes.hpp" line="621"/>
         <source>tellarknight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="622"/>
+        <location filename="../src/archetypes.hpp" line="622"/>
         <source>Shaddoll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="623"/>
+        <location filename="../src/archetypes.hpp" line="623"/>
         <source>Yang Zing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="624"/>
+        <location filename="../src/archetypes.hpp" line="624"/>
         <source>Performapal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="625"/>
+        <location filename="../src/archetypes.hpp" line="625"/>
         <source>lswarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="626"/>
+        <location filename="../src/archetypes.hpp" line="626"/>
         <source>Legendary Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="627"/>
+        <location filename="../src/archetypes.hpp" line="627"/>
         <source>Masked HERO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="628"/>
+        <location filename="../src/archetypes.hpp" line="628"/>
         <source>Nordic Alfar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="629"/>
+        <location filename="../src/archetypes.hpp" line="629"/>
         <source>Legendary Dragon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="630"/>
+        <location filename="../src/archetypes.hpp" line="630"/>
         <source>Spiritual Wind Art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="632"/>
+        <location filename="../src/archetypes.hpp" line="632"/>
         <source>Stardust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="633"/>
+        <location filename="../src/archetypes.hpp" line="633"/>
         <source>Kuriboh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="634"/>
+        <location filename="../src/archetypes.hpp" line="634"/>
         <source>Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="635"/>
+        <location filename="../src/archetypes.hpp" line="635"/>
         <source>sprout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="636"/>
+        <location filename="../src/archetypes.hpp" line="636"/>
         <source>Artorigus</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="637"/>
+        <location filename="../src/archetypes.hpp" line="637"/>
         <source>Laundsallyn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="638"/>
+        <location filename="../src/archetypes.hpp" line="638"/>
         <source>Fluffal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="639"/>
+        <location filename="../src/archetypes.hpp" line="639"/>
         <source>Qli</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="640"/>
+        <location filename="../src/archetypes.hpp" line="640"/>
         <source>Deskbot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="641"/>
+        <location filename="../src/archetypes.hpp" line="641"/>
         <source>Goblin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="642"/>
+        <location filename="../src/archetypes.hpp" line="642"/>
         <source>Frightfur</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="643"/>
+        <location filename="../src/archetypes.hpp" line="643"/>
         <source>Dark Contract</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="644"/>
+        <location filename="../src/archetypes.hpp" line="644"/>
         <source>D/D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="645"/>
+        <location filename="../src/archetypes.hpp" line="645"/>
         <source>Infernity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="646"/>
+        <location filename="../src/archetypes.hpp" line="646"/>
         <source>Gottoms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="647"/>
+        <location filename="../src/archetypes.hpp" line="647"/>
         <source>Burning Abyss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="648"/>
+        <location filename="../src/archetypes.hpp" line="648"/>
         <source>U.A.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="649"/>
+        <location filename="../src/archetypes.hpp" line="649"/>
         <source>Yosenju</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="650"/>
+        <location filename="../src/archetypes.hpp" line="650"/>
         <source>Nekroz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="651"/>
+        <location filename="../src/archetypes.hpp" line="651"/>
         <source>Ritual Beast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="652"/>
+        <location filename="../src/archetypes.hpp" line="652"/>
         <source>Entity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="653"/>
+        <location filename="../src/archetypes.hpp" line="653"/>
         <source>Blaze Accelerator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="654"/>
+        <location filename="../src/archetypes.hpp" line="654"/>
         <source>Raidraptor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="655"/>
+        <location filename="../src/archetypes.hpp" line="655"/>
         <source>Infernoid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="656"/>
+        <location filename="../src/archetypes.hpp" line="656"/>
         <source>Jinzo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="657"/>
+        <location filename="../src/archetypes.hpp" line="657"/>
         <source>Gaia The Fierce Knight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="658"/>
+        <location filename="../src/archetypes.hpp" line="658"/>
         <source>Monarch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="659"/>
+        <location filename="../src/archetypes.hpp" line="659"/>
         <source>Charmer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="660"/>
+        <location filename="../src/archetypes.hpp" line="660"/>
         <source>Alien</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="661"/>
+        <location filename="../src/archetypes.hpp" line="661"/>
         <source>Possessed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="662"/>
+        <location filename="../src/archetypes.hpp" line="662"/>
         <source>Destiny HERO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="663"/>
+        <location filename="../src/archetypes.hpp" line="663"/>
         <source>PSY-Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="664"/>
+        <location filename="../src/archetypes.hpp" line="664"/>
         <source>Power Tool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="665"/>
+        <location filename="../src/archetypes.hpp" line="665"/>
         <source>Edge Imp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="666"/>
+        <location filename="../src/archetypes.hpp" line="666"/>
         <source>Zefra</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="667"/>
+        <location filename="../src/archetypes.hpp" line="667"/>
         <source>Void</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="668"/>
+        <location filename="../src/archetypes.hpp" line="668"/>
         <source>Performage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="669"/>
+        <location filename="../src/archetypes.hpp" line="669"/>
         <source>Dracoslayer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="670"/>
+        <location filename="../src/archetypes.hpp" line="670"/>
         <source>Igknight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="671"/>
+        <location filename="../src/archetypes.hpp" line="671"/>
         <source>Aroma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="672"/>
+        <location filename="../src/archetypes.hpp" line="672"/>
         <source>Empowered Warrior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="673"/>
+        <location filename="../src/archetypes.hpp" line="673"/>
         <source>Aether</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="674"/>
+        <location filename="../src/archetypes.hpp" line="674"/>
         <source>Prediction Princess</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="676"/>
+        <location filename="../src/archetypes.hpp" line="676"/>
         <source>Chaos</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="677"/>
+        <location filename="../src/archetypes.hpp" line="677"/>
         <source>Saber</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="678"/>
+        <location filename="../src/archetypes.hpp" line="678"/>
         <source>Majespecter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="679"/>
+        <location filename="../src/archetypes.hpp" line="679"/>
         <source>Graydle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="680"/>
+        <location filename="../src/archetypes.hpp" line="680"/>
         <source>Kozmo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="681"/>
+        <location filename="../src/archetypes.hpp" line="681"/>
         <source>Kaiju</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="683"/>
+        <location filename="../src/archetypes.hpp" line="683"/>
         <source>Dante</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="684"/>
+        <location filename="../src/archetypes.hpp" line="684"/>
         <source>Destruction Sword</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="685"/>
+        <location filename="../src/archetypes.hpp" line="685"/>
         <source>Buster Blader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="686"/>
+        <location filename="../src/archetypes.hpp" line="686"/>
         <source>Dinomist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="687"/>
+        <location filename="../src/archetypes.hpp" line="687"/>
         <source>Shiranui</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="688"/>
+        <location filename="../src/archetypes.hpp" line="688"/>
         <source>Dracoverlord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="689"/>
+        <location filename="../src/archetypes.hpp" line="689"/>
         <source>Phantom Knights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="690"/>
+        <location filename="../src/archetypes.hpp" line="690"/>
         <source>Super Quant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="691"/>
+        <location filename="../src/archetypes.hpp" line="691"/>
         <source>Blue-Eyes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="692"/>
+        <location filename="../src/archetypes.hpp" line="692"/>
         <source>Exodia</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="693"/>
+        <location filename="../src/archetypes.hpp" line="693"/>
         <source>Lunalight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="694"/>
+        <location filename="../src/archetypes.hpp" line="694"/>
         <source>Watt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="695"/>
+        <location filename="../src/archetypes.hpp" line="695"/>
         <source>Amorphage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="696"/>
+        <location filename="../src/archetypes.hpp" line="696"/>
         <source>Metalfoes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="697"/>
+        <location filename="../src/archetypes.hpp" line="697"/>
         <source>Triamid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="698"/>
+        <location filename="../src/archetypes.hpp" line="698"/>
         <source>Cubic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="699"/>
+        <location filename="../src/archetypes.hpp" line="699"/>
         <source>Celtic Guard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="700"/>
+        <location filename="../src/archetypes.hpp" line="700"/>
         <source>Cipher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="701"/>
+        <location filename="../src/archetypes.hpp" line="701"/>
         <source>Flower Cardian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="702"/>
+        <location filename="../src/archetypes.hpp" line="702"/>
         <source>Silent Swordsman</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="703"/>
+        <location filename="../src/archetypes.hpp" line="703"/>
         <source>Silent Magician</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="704"/>
+        <location filename="../src/archetypes.hpp" line="704"/>
         <source>Magna Warrior</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="705"/>
+        <location filename="../src/archetypes.hpp" line="705"/>
         <source>Crystron</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="706"/>
+        <location filename="../src/archetypes.hpp" line="706"/>
         <source>Chemicritter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="707"/>
+        <location filename="../src/archetypes.hpp" line="707"/>
         <source>Abyss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="708"/>
+        <location filename="../src/archetypes.hpp" line="708"/>
         <source>Subterror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="709"/>
+        <location filename="../src/archetypes.hpp" line="709"/>
         <source>SPYRAL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="710"/>
+        <location filename="../src/archetypes.hpp" line="710"/>
         <source>Darklord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="711"/>
+        <location filename="../src/archetypes.hpp" line="711"/>
         <source>Ojama</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="712"/>
+        <location filename="../src/archetypes.hpp" line="712"/>
         <source>Windwitch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="713"/>
+        <location filename="../src/archetypes.hpp" line="713"/>
         <source>Zoodiac</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="715"/>
+        <location filename="../src/archetypes.hpp" line="715"/>
         <source>Predap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="716"/>
+        <location filename="../src/archetypes.hpp" line="716"/>
         <source>Invoked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="717"/>
+        <location filename="../src/archetypes.hpp" line="717"/>
         <source>Gandora</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="718"/>
+        <location filename="../src/archetypes.hpp" line="718"/>
         <source>Skyscraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="719"/>
+        <location filename="../src/archetypes.hpp" line="719"/>
         <source>Lyrilusc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="720"/>
+        <location filename="../src/archetypes.hpp" line="720"/>
         <source>Supreme King</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="721"/>
+        <location filename="../src/archetypes.hpp" line="721"/>
         <source>True Draco|True King</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="722"/>
+        <location filename="../src/archetypes.hpp" line="722"/>
         <source>Phantasm Spiral</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="723"/>
+        <location filename="../src/archetypes.hpp" line="723"/>
         <source>Trickstar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="724"/>
+        <location filename="../src/archetypes.hpp" line="724"/>
         <source>Gouki</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="725"/>
+        <location filename="../src/archetypes.hpp" line="725"/>
         <source>World Chalice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="726"/>
+        <location filename="../src/archetypes.hpp" line="726"/>
         <source>World Legacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/archetypes.hpp" line="727"/>
+        <location filename="../src/archetypes.hpp" line="727"/>
         <source>Clear Wing</source>
         <translation type="unfinished"></translation>
     </message>

--- a/res/lang.qrc
+++ b/res/lang.qrc
@@ -1,0 +1,6 @@
+<!DOCTYPE RCC>
+<RCC version="1.0">
+  <qresource>
+      <file>es.qm</file>
+  </qresource>
+</RCC>

--- a/res/meson.build
+++ b/res/meson.build
@@ -1,2 +1,2 @@
-ts_files = qt_mod.compile_translations(ts_files : 'es.ts')
+ts_files = qt_mod.compile_translations(qresource : 'lang.qrc')
 res_files = qt_mod.compile_resources(sources : 'res.qrc')


### PR DESCRIPTION
The proper way was to have a qrc file so that the generated translations would also be embedded in the final binary, also workaround the limitation of the visual studio generator where it wouldn't properly generate the qm files by manually running that target.