### PR TITLE
Forcefully center window on Windows

### DIFF
--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -395,9 +395,11 @@ MainWindow::MainWindow(QWidget* parent)
 {
 	(void)spanishTranslator->load(":/es");
 	ui->setupUi(this);
+#ifdef Q_OS_WIN
 	setGeometry(
 		QStyle::alignedRect(Qt::LeftToRight, Qt::AlignCenter, size(),
 	                        QGuiApplication::primaryScreen()->geometry()));
+#endif
 	connect(ui->actionNewDatabase, &QAction::triggered, this,
 	        &MainWindow::newDatabase);
 	connect(ui->actionOpenDatabase, &QAction::triggered, this,

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -5,6 +5,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QRegularExpressionValidator>
+#include <QScreen>
 #include <QScrollBar>
 #include <QSqlDatabase>
 #include <QSqlError>
@@ -394,6 +395,9 @@ MainWindow::MainWindow(QWidget* parent)
 {
 	(void)spanishTranslator->load(":/es");
 	ui->setupUi(this);
+	setGeometry(
+		QStyle::alignedRect(Qt::LeftToRight, Qt::AlignCenter, size(),
+	                        QGuiApplication::primaryScreen()->geometry()));
 	connect(ui->actionNewDatabase, &QAction::triggered, this,
 	        &MainWindow::newDatabase);
 	connect(ui->actionOpenDatabase, &QAction::triggered, this,


### PR DESCRIPTION
On Windows the window spawns sometimes in random locations, on Windows 11 sometimes it spawns off the screen, or in general it doesn't start centered.
Make so that it is forcefully centered on start.
This is enabled only for windows as on Linux (at least with KDE) the window is properly spawn centered already.