### PR TITLE
Allow closing tabs with middle mouse click

### DIFF
--- a/src/gui/main_window.hpp
+++ b/src/gui/main_window.hpp
@@ -37,6 +37,9 @@ private slots:
 
 	void openHomepage();
 
+protected:
+	bool eventFilter(QObject* obj, QEvent* event) override;
+
 private:
 	std::unique_ptr<QTranslator> const spanishTranslator;
 	std::unique_ptr<Ui::MainWindow> const ui;


### PR DESCRIPTION
Since the QTabWidget doesn't listen to middle mouse events by itself, an event filter was added, that function looks for middle mouse button events performed on such widget and raises the ``tabCloseRequested`` signal as if it was raised internally by the widget.